### PR TITLE
Correct case of dependency name in library.properties depends field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=Supports all basic types plus String, std::string, and ArduinoJSON.
 category=Data Storage
 url=https://github.com/thebigpotatoe/Effortless-SPIFFS
 architectures=esp8266
-depends=ArduinoJSON
+depends=ArduinoJson
 license=MIT


### PR DESCRIPTION
The Arduino Library Manager dependencies system is case sensitive and the correct library name is `ArduinoJson`, not `ArduinoJSON`:
https://github.com/bblanchon/ArduinoJson/blob/6.x/library.properties#L1